### PR TITLE
TOUCHFILE to include time stamp - avoid race conditions

### DIFF
--- a/check_mountpoints.sh
+++ b/check_mountpoints.sh
@@ -25,6 +25,8 @@
 # @version: 1.16
 # @date: 2014-06-16 15:42:12 CEST
 #
+# changes 1.19
+#  - for write test, use filename, which is less prone to race conditions
 # changes 1.18
 #  - write check respects stale timeout now
 # changes 1.17
@@ -269,7 +271,7 @@ for MP in ${MPS} ; do
                         ERR_MESG[${#ERR_MESG[*]}]="${MP} doesn't exist on filesystem"
                 elif [ ${WRITETEST} -eq 1 ]; then
                 ## if wanted, check if it is writable
-                        TOUCHFILE=${MP}/.mount_test_from_$(hostname)
+                        TOUCHFILE=${MP}/.mount_test_from_$(hostname)_$(date +%Y-%m-%d--%H-%M-%S).$RANDOM.$$
                         touch ${TOUCHFILE} &>/dev/null &
                         TOUCHPID=$!
                         for (( i=1 ; i<$TIME_TILL_STALE ; i++ )) ; do


### PR DESCRIPTION
It's rather easily possible, that the $TOUCHFILE already exists, maybe from a previous run, or so. Add a timestamp to the filename and a random number and the current pid.

This should make it close to "impossible" that the file exists from previous runs or so.

Would've liked to use mktemp, but I'm unsure how portable "mktemp -u" (do not create anything; merely print a name (unsafe)) would've been.