### PR TITLE
Added LIBEXEC path to support op5 Monitor

### DIFF
--- a/check_mountpoints.sh
+++ b/check_mountpoints.sh
@@ -94,7 +94,7 @@ IGNOREFSTAB=0
 WRITETEST=0
 
 export PATH="/bin:/usr/local/bin:/sbin:/usr/bin:/usr/sbin:/usr/sfw/bin"
-LIBEXEC="/opt/nagios/libexec /usr/lib64/nagios/plugins /usr/lib/nagios/plugins /usr/local/nagios/libexec /usr/local/icinga/libexec /usr/local/libexec /opt/csw/libexec/nagios-plugins"
+LIBEXEC="/opt/nagios/libexec /usr/lib64/nagios/plugins /usr/lib/nagios/plugins /usr/local/nagios/libexec /usr/local/icinga/libexec /usr/local/libexec /opt/csw/libexec/nagios-plugins /opt/plugins"
 for i in ${LIBEXEC} ; do
   [ -r ${i}/utils.sh ] && . ${i}/utils.sh
 done


### PR DESCRIPTION
The monitoring product op5 Monitor (built on a Nagios fork) stores it's plugins and utilities in the path "/opt/plugins", which I've added to "LIBEXEC".