### PR TITLE
Be more generic about FS types

### DIFF
--- a/check_mountpoints.sh
+++ b/check_mountpoints.sh
@@ -240,7 +240,7 @@ for MP in ${MPS} ; do
         ## If its an OpenVZ Container or -a Mode is selected skip fstab check.
         ## -a Mode takes mounts from fstab, we do not have to check if they exist in fstab ;)
         if [ ! -f /proc/vz/veinfo -a ${AUTO} -ne 1 -a ${IGNOREFSTAB} -ne 1 ]; then
-                awk '{if ($'${FSF}'=="ext3" || $'${FSF}'=="auto" || $'${FSF}'=="ext4" || $'${FSF}'=="nfs" || $'${FSF}'=="nfs4" || $'${FSF}'=="davfs" || $'${FSF}'=="cifs" || $'${FSF}'=="fuse" || $'${FSF}'=="glusterfs" || $'${FSF}'=="ocfs2" || $'${FSF}'=="lustre"){print $'${MF}'}}' ${FSTAB} | ${GREP} -q ${MP} &>/dev/null
+                awk '{print $'${MF}'}' "${FSTAB}" | "${GREP}" -q ${MP} &>/dev/null
                 if [ $? -ne 0 ]; then
                         log "CRIT: ${MP} doesn't exist in /etc/fstab"
                         ERR_MESG[${#ERR_MESG[*]}]="${MP} doesn't exist in fstab ${FSTAB}"
@@ -248,7 +248,7 @@ for MP in ${MPS} ; do
         fi
 
         ## check kernel mounts
-        ${GREP} "${MP}" ${MTAB} | ${GREP} -q -E "(ext3|auto|ext4|nfs|nfs4|davfs|cifs|fuse|simfs|glusterfs|ocfs2|lustre)" &>/dev/null
+        ${GREP} "${MP}" ${MTAB} &>/dev/null
         if [ $? -ne 0 ]; then
         ## if a softlink is not an adequate replacement
         	if [ -z "$LINKOK" -o ! -L ${MP} ]; then


### PR DESCRIPTION
I could not find a reason to filter based on fs type when a user manually specifies a mountpoint.

This pull request removes the check for file system types.