### PR TITLE
Add support for FS type enforcing

### DIFF
--- a/check_mountpoints.sh
+++ b/check_mountpoints.sh
@@ -131,6 +131,7 @@ case $KERNEL in
          FSTAB=/etc/vfstab
          MTAB=/etc/mnttab
          GREP=ggrep
+         STAT=stat
          ;;
   HP-UX) FSF=3
          MF=2
@@ -139,6 +140,7 @@ case $KERNEL in
          FSTAB=/etc/fstab
          MTAB=/dev/mnttab
          GREP=grep
+         STAT=stat
          ;;
   FreeBSD) FSF=3
          MF=2
@@ -147,6 +149,7 @@ case $KERNEL in
          FSTAB=/etc/fstab
          MTAB=none
          GREP=grep
+         STAT=stat
 	 ;;
   *)     FSF=3
          MF=2
@@ -155,6 +158,7 @@ case $KERNEL in
          FSTAB=/etc/fstab
          MTAB=/proc/mounts
          GREP=grep
+         STAT=stat
          ;;
 esac
 
@@ -190,6 +194,7 @@ function usage() {
         echo " -o          When autoselecting mounts from fstab, ignore mounts having noauto flag. (default: unset)"
         echo " -w          Writetest. Touch file \$mountpoint/.mount_test_from_\$(hostname) (default: unset)"
         echo " -e ARGS     Extra arguments for df (default: unset)"
+        echo " -t FS_TYPE  FS Type to check for using stat. Multiple values should be separated with commas (default: unset)"
         echo " MOUNTPOINTS list of mountpoints to check. Ignored when -a is given"
 }
 
@@ -246,6 +251,7 @@ do
                 -w) WRITETEST=1; shift;;
                 -L) LINKOK=1; shift;;
                 -e) DFARGS=$2; shift 2;; 
+                -t) FSTYPE=$2; shift 2;;
                 /*) MPS="${MPS} $1"; shift;;
                 *) usage; exit $STATE_UNKNOWN;;
         esac
@@ -321,6 +327,13 @@ if [ ! -e "${MTAB}" ]; then
         exit $STATE_CRITICAL
 fi
 
+if [ -n "${FSTYPE}" ]; then
+        # split on commas
+        oIFS=$IFS
+        IFS=, read -a fstypes <<<"${FSTYPE}"
+        IFS=$oIFS
+fi
+
 # --------------------------------------------------------------------
 # now we check if the given parameters ...
 #  1) ... exist in the /etc/fstab
@@ -329,6 +342,7 @@ fi
 #  4) ... exist on the filesystem
 #  5) ... is writable (optional)
 # --------------------------------------------------------------------
+mpidx=0
 for MP in ${MPS} ; do
         ## If its an OpenVZ Container or -a Mode is selected skip fstab check.
         ## -a Mode takes mounts from fstab, we do not have to check if they exist in fstab ;)
@@ -408,6 +422,29 @@ for MP in ${MPS} ; do
                 fi
         fi
 
+        # Check for FS type using stat
+        efstype=${fstypes[$mpidx]}
+        ((mpidx++))
+
+        if [ -z "${efstype}" ]
+        then
+            continue
+        fi
+
+        rfstype=$(${STAT} -f --printf='%T' "${MP}")
+        if [ $? -ne 0 ]
+        then
+            log "CRIT: Fail to fetch FS type for ${MP}"
+            ERR_MESG[${#ERR_MESG[*]}]="Fail to fetch FS type for ${MP}"
+            continue
+        fi
+
+        if [ "${rfstype}" != "${efstype}" ]
+        then
+            log "CRIT: Bad FS type for ${MP}"
+            ERR_MESG[${#ERR_MESG[*]}]="Bad FS type for ${MP}. Got '${rfstype}' while '${efstype}' was expected"
+            continue
+        fi
 done
 
 # Remove temporary files


### PR DESCRIPTION
`stat` is used to detect the FS type and compare the value to the expected one.

Example:

```
$ check_mountpoints.sh -t nfs /var
CRITICAL: Bad FS type for /var. Got 'ext2/ext3' while 'nfs' was expected ;

$ check_mountpoints.sh -t ext2/ext3 /var
OK: all mounts were found ( /var)
```

Multiple values could be supplied separated by `,`.

This patch has only been tested on Linux.